### PR TITLE
Increase move confidence

### DIFF
--- a/src/engine/newMailHandler.ts
+++ b/src/engine/newMailHandler.ts
@@ -148,9 +148,12 @@ export default class NewMailHandler {
       ]
     });
 
-    if (destination - secondHighest > this.userConnection.user.moveThreshold) {
+    const moveConfidence = destination - secondHighest * inbox;
+
+    if (moveConfidence > this.userConnection.user.moveThreshold) {
       return folderName;
     }
+
     return null;
   };
 }


### PR DESCRIPTION
If there's low confidence the message should remain in the inbox.

If there's 2 highly likely candidate destinations for the message outside
the inbox, the algorithm is hesitant to move messages even if the inbox has
0 confidence that the message should reside there.

In this case, the best option is likely still to choose the box with the
highest confidence.