### PR TITLE
Access the user name safely

### DIFF
--- a/src/engine/userConnection.ts
+++ b/src/engine/userConnection.ts
@@ -191,7 +191,11 @@ export default class UserConnection implements IBoxListener {
   }
 
   public onClose(hadError: boolean) {
-    logger.warn(`Connection for ${this.user.user} closed${hadError ? ' with error.' : '.'}`);
+    logger.warn(
+      `Connection for ${_.get(this, 'userReference.user', 'unknown user')} closed${
+        hadError ? ' with error.' : '.'
+      }`
+    );
     if (this.onDisconnect) {
       this.onDisconnect();
     }


### PR DESCRIPTION
Somehow this is sometimes undefined. There must be something happening that
type-safety is not catching. All the values should be guaranteed to be
defined (haha).