### PR TITLE
Correct the race condition if a mail comes in while the connection inits

### DIFF
--- a/src/engine/userConnection.ts
+++ b/src/engine/userConnection.ts
@@ -191,9 +191,9 @@ export default class UserConnection implements IBoxListener {
     }
 
     this.mailBoxes = resultingBoxes;
+    this.mailBoxes.forEach(this.currentPredictor.considerBox);
     await this.openInbox();
     this.attempts = 0;
-    this.mailBoxes.forEach(this.currentPredictor.considerBox);
     await this.refresh();
 
     logger.info('init complete');


### PR DESCRIPTION
This was a real bug, just only seen occasionally in testing. This change
introduces a fix and tests for the correct initialization order to prevent
the race condition from occurring.