### PR TITLE
Handle another kind of not authenticated error with backoff

### DIFF
--- a/src/glue.ts
+++ b/src/glue.ts
@@ -18,6 +18,13 @@ function canFixByReconnecting(reason: any): boolean {
     }
   }
 
+  if (reason.message) {
+    switch (reason.message) {
+      case 'Not authenticated':
+        return true;
+    }
+  }
+
   return false;
 }
 


### PR DESCRIPTION
This came up once with an authenticated client as an unrecoverable error.