### PR TITLE
Disconnections don't recover

### DIFF
--- a/src/engine/exceptions.ts
+++ b/src/engine/exceptions.ts
@@ -1,0 +1,5 @@
+export class BadStateException extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/src/engine/userConnection.ts
+++ b/src/engine/userConnection.ts
@@ -232,6 +232,7 @@ export default class UserConnection implements IBoxListener {
         hadError ? ' with error.' : '.'
       }`
     );
+
     if (this.disconnectCallback) {
       this.disconnectCallback();
     }
@@ -239,6 +240,17 @@ export default class UserConnection implements IBoxListener {
 
   set onDisconnect(callback: OnDisconnect | undefined) {
     this.disconnectCallback = callback;
+  }
+
+  public onEnd() {
+    logger.debug('Connection ended.');
+
+    if (this.disconnectCallback) {
+      logger.debug('Attempting to reconnect.');
+      this.disconnectCallback();
+    } else {
+      logger.debug('No disconnect callback found.');
+    }
   }
 
   public onExpunge = async (seqNo: number) => {

--- a/src/engine/userConnection.ts
+++ b/src/engine/userConnection.ts
@@ -3,16 +3,17 @@ import {Map} from 'immutable';
 import * as _ from 'lodash';
 
 import Box from './box';
+import {BadStateException} from './exceptions';
 import {canLearnFrom} from '../imap/boxFeatures';
 import {OnDisconnect} from '../imap/functions';
 import Promisified, {IBoxListener} from '../imap/promisified';
 import logger from '../logger';
+import NewMailHandler from './newMailHandler';
 import IPersistence from '../persistence/persistence';
 import User from '../persistence/user';
 import IPredictor from './predictor';
 import {create as createPredictors, PredictorType} from './predictors';
 import {getSyncedTo, withTrialSettings} from '../tools/trialSettings';
-import NewMailHandler from './newMailHandler';
 import {messageFromBody, Message} from '../types/message';
 import Move, {createMovesFromJson} from '../types/move';
 
@@ -26,13 +27,13 @@ export default class UserConnection implements IBoxListener {
   private currentlyOpen?: Box;
   private disconnectCallback?: OnDisconnect;
   private inbox?: Box;
-  private mailBoxes: ReadonlyArray<Box>;
+  private mailBoxes?: ReadonlyArray<Box>;
   private newMailHander: NewMailHandler;
   private readonly persistenceReference: IPersistence;
   private readonly pImap: Promisified;
   private readonly predictors: Map<PredictorType, IPredictor>;
   private readonly currentPredictor: IPredictor;
-  private refreshTimer: NodeJS.Timer;
+  private refreshTimer?: NodeJS.Timer;
   private readonly userReference: User;
   private isPopulatingBox: boolean = false;
   private isShallowSyncing: boolean = false;
@@ -44,12 +45,15 @@ export default class UserConnection implements IBoxListener {
     this.attempts = connectionAttempts;
     this.persistenceReference = persistence;
     this.pImap = new Promisified(new Imap(user), this);
+    this.movesList = [];
+    this.movesMap = {};
+    this.newMailHander = new NewMailHandler(this, this.pImap);
     this.predictors = createPredictors();
     this.currentPredictor = this.predictors.get(u.predictorType || 'Traat') as IPredictor;
     this.userReference = user;
   }
 
-  get boxes(): ReadonlyArray<Box> {
+  get boxes(): ReadonlyArray<Box> | undefined {
     return this.mailBoxes;
   }
 
@@ -134,8 +138,9 @@ export default class UserConnection implements IBoxListener {
   public async init() {
     logger.debug('starting connection init');
     const persistedBoxes: ReadonlyArray<Box> = (await this.persistence.listBoxes(this.user)) || [];
-    this.movesList = createMovesFromJson(await this.persistence.listMoves(this.user));
-    this.movesMap = {};
+    this.movesList = this.movesList.concat(
+      createMovesFromJson(await this.persistence.listMoves(this.user))
+    );
     this.movesList.forEach(move => (this.movesMap[move.message.headers] = move));
     await this.pImap.waitForConnection(() => {
       this.currentlyOpen = undefined;
@@ -143,7 +148,6 @@ export default class UserConnection implements IBoxListener {
         this.disconnectCallback();
       }
     });
-    this.newMailHander = new NewMailHandler(this, this.pImap);
     const writablePersistedBoxes: Box[] = persistedBoxes.map(box => box);
     const mailBoxes = await this.pImap.getBoxes();
     const discoveredBoxes = this.collectMailboxes(mailBoxes);
@@ -228,13 +232,9 @@ export default class UserConnection implements IBoxListener {
         hadError ? ' with error.' : '.'
       }`
     );
-    if (this.onDisconnect) {
-      this.onDisconnect();
+    if (this.disconnectCallback) {
+      this.disconnectCallback();
     }
-  }
-
-  get onDisconnect() {
-    return this.disconnectCallback;
   }
 
   set onDisconnect(callback: OnDisconnect | undefined) {
@@ -449,6 +449,10 @@ export default class UserConnection implements IBoxListener {
 
     try {
       this.isShallowSyncing = true;
+      if (this.boxes === undefined) {
+        throw new BadStateException('Mailboxes have not yet been retrieved.');
+      }
+
       for (const box of this.boxes
         .filter(box => canLearnFrom(box.qualifiedName))
         .filter(box => excluding.indexOf(box.qualifiedName) === -1)) {

--- a/src/glue.ts
+++ b/src/glue.ts
@@ -33,17 +33,12 @@ class Glue {
   readonly synchronizer: Synchronizer;
 
   constructor() {
-    this.persistence = new Json();
+    this.persistence = new Json(this.path());
     this.synchronizer = new Synchronizer(this.persistence);
   }
 
   async init() {
-    await this.persistence.init(
-      env
-        .get('M_FAMILIAR_STORAGE')
-        .required()
-        .asString()
-    );
+    await this.persistence.init(this.path());
     await this.synchronizer.init();
   }
 
@@ -54,6 +49,13 @@ class Glue {
     }
 
     return false;
+  }
+
+  private path(): string {
+    return env
+      .get('M_FAMILIAR_STORAGE')
+      .required()
+      .asString();
   }
 }
 

--- a/src/imap/promisified.ts
+++ b/src/imap/promisified.ts
@@ -6,6 +6,7 @@ import logger from '../logger';
 
 export interface IBoxListener {
   onClose: (hadError: boolean) => void;
+  onEnd: () => void;
   onExpunge: (seqNo: number) => void;
   onMail: (count: number) => void;
   onUidValidity: (validity: number) => void;
@@ -77,10 +78,11 @@ export default class Promisified {
 
   private setBoxListener = (listener: IBoxListener) => {
     this.imap.on('close', listener.onClose);
+    this.imap.on('end', listener.onEnd);
     this.imap.on('expunge', listener.onExpunge);
     this.imap.on('mail', listener.onMail);
     this.imap.on('uidvalidity', listener.onUidValidity);
-    ['alert', 'end', 'update'].forEach(event => {
+    ['alert', 'update'].forEach(event => {
       this.imap.on(event, (...args: any[]) => {
         logger.error({
           args,

--- a/src/imap/promisified.ts
+++ b/src/imap/promisified.ts
@@ -32,12 +32,12 @@ export default class Promisified {
     this.imap = imap;
     this.setBoxListener(listener);
 
-    this.closeBox = promisify<void>(imap.closeBox.bind(imap));
-    this.getBoxes = promisify<Imap.MailBoxes>(imap.getBoxes.bind(imap));
-    this.move = promisify<string[], string, void>(imap.move.bind(imap));
-    this.openBox = promisify<string, Imap.Box>(imap.openBox.bind(imap));
-    this.search = promisify<any[], number[]>(imap.search.bind(imap));
-    this.subscribeBox = promisify<string, void>(imap.subscribeBox.bind(imap));
+    this.closeBox = promisify(imap.closeBox.bind(imap));
+    this.getBoxes = promisify(imap.getBoxes.bind(imap));
+    this.move = promisify(imap.move.bind(imap));
+    this.openBox = promisify(imap.openBox.bind(imap));
+    this.search = promisify(imap.search.bind(imap));
+    this.subscribeBox = promisify(imap.subscribeBox.bind(imap));
   }
 
   fetch = (fetch: Imap.ImapFetch): Promise<ReadonlyArray<MessageBody>> => {

--- a/src/persistence/json.ts
+++ b/src/persistence/json.ts
@@ -95,15 +95,17 @@ function stringify(value: any, depth: number = 0): string {
 }
 
 export default class Json implements IInitializablePersistence<string> {
-  private contentsFolder: string;
+  private readonly contentsFolder: string;
+
+  public constructor(contentsFolder: string) {
+    this.contentsFolder = contentsFolder;
+  }
 
   public userDataRoot(user: User): string {
     return path.join(this.contentsFolder, hashOf(user.user));
   }
 
-  async init(contentsFolder: string) {
-    this.contentsFolder = contentsFolder;
-  }
+  async init(_: string) {}
 
   private boxName(box: Box): string {
     return hashOf(box.qualifiedName);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,10 +9,12 @@
     "moduleResolution": "node",
     "noImplicitAny": true,
     "noImplicitReturns": true,
+    "noImplicitThis": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "resolveJsonModule": true,
     "sourceMap": true,
+    "strict": true,
     "strictFunctionTypes": true,
     "strictNullChecks": true,
     "target": "es2017"


### PR DESCRIPTION
Before the unknown disconnection sequence causes the onClose event with no object state available, an 'end' event takes place. Perhaps handling reconnection here is a better approach?

This PR doesn't necessarily fix the disconnection behaviour that has been observed. The cause of this is still unknown.