### PR TITLE
Include prior errors in predictions

### DIFF
--- a/src/engine/crossCorrelate.ts
+++ b/src/engine/crossCorrelate.ts
@@ -3,6 +3,7 @@ import {Map as ImMap} from 'immutable';
 import Box from './box';
 import Predictor from './predictor';
 import {crossCorrelateStrings} from '../tools/crossCorrelate';
+import Mistake from 'types/mistake';
 
 const MODE_SLOTS = 100;
 
@@ -28,6 +29,9 @@ export default class CrossCorrelate implements Predictor {
     headersList.push(headers);
     this.boxToHeaders.set(qualifiedBoxName, headersList);
   }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  addMistake(_mistake: Mistake): void {}
 
   considerBox(box: Box): void {
     for (const message of box.messages) {

--- a/src/engine/mistakeTracker.ts
+++ b/src/engine/mistakeTracker.ts
@@ -1,0 +1,65 @@
+import _ = require('lodash');
+
+import Box from './box';
+import Mistake, {createMistake} from '../types/mistake';
+import Move from '../types/move';
+import {Message} from 'types/message';
+
+export type MistakesByHeader = _.Dictionary<Mistake>;
+export type MistakeObserver = (mistake: Mistake) => void;
+
+export default class MistakeTracker {
+  readonly mistakesByErrantDestination: _.Dictionary<MistakesByHeader>;
+  readonly movesByHeader: _.Dictionary<Move>;
+  readonly observer?: MistakeObserver;
+
+  constructor(
+    moves: ReadonlyArray<Move>,
+    initializedBoxen: ReadonlyArray<Box>,
+    observer?: MistakeObserver
+  ) {
+    this.movesByHeader = _.fromPairs(_.map(moves, move => [move.message.headers, move]));
+    this.mistakesByErrantDestination = {};
+    this.observer = observer;
+    initializedBoxen.forEach(box => {
+      const qualifiedName = box.qualifiedName;
+      box.messages.forEach(message => {
+        const move: Move | undefined = this.movesByHeader[message.headers];
+        if (move && move.destination !== qualifiedName) {
+          this.addMistake(createMistake(qualifiedName, move));
+        }
+      });
+    });
+  }
+
+  addMove(move: Move): void {
+    this.movesByHeader[move.message.headers] = move;
+  }
+
+  inspectMessage(qualifiedBoxName: string, message: Message): void {
+    const move = this.movesByHeader[message.headers];
+    if (!move || qualifiedBoxName === move.destination) {
+      return;
+    }
+
+    this.addMistake(createMistake(qualifiedBoxName, move));
+  }
+
+  mistakesFor(destination: string): MistakesByHeader {
+    return this.mistakesByErrantDestination[destination] || {};
+  }
+
+  private addMistake(mistake: Mistake): void {
+    if (!this.mistakesByErrantDestination[mistake.errantMove.destination]) {
+      this.mistakesByErrantDestination[mistake.errantMove.destination] = {};
+    }
+
+    this.mistakesByErrantDestination[mistake.errantMove.destination][
+      mistake.errantMove.message.headers
+    ] = mistake;
+
+    if (this.observer) {
+      this.observer(mistake);
+    }
+  }
+}

--- a/src/engine/predictor.ts
+++ b/src/engine/predictor.ts
@@ -1,6 +1,7 @@
 import {Map} from 'immutable';
 
 import Box from './box';
+import Mistake from 'types/mistake';
 
 export class UndeclaredBoxError extends Error {
   constructor(qualifiedBoxName: string) {
@@ -13,6 +14,7 @@ export class UndeclaredBoxError extends Error {
 
 export default interface Predictor {
   addHeaders(header: string, qualifiedBoxName: string): void;
+  addMistake(mistake: Mistake): void;
   considerBox(box: Box): void;
   folderScore(headers: string): Map<string, number>;
   name(): string;

--- a/src/engine/regexAndAtable.ts
+++ b/src/engine/regexAndAtable.ts
@@ -5,6 +5,7 @@ import Box from './box';
 import {canMoveTo} from '../imap/boxFeatures';
 import Predictor from './predictor';
 import MIN_SEGMENT_LENGTHS from './segmentLengths';
+import Mistake from 'types/mistake';
 
 interface DiffAndAtablesInstance {
   daa: DiffAndAtables;
@@ -28,6 +29,9 @@ export default class RegexAndAtable implements Predictor {
       instance => DiffAndAtables.addStrings(instance.daa, [headers], instance.minSegmentLength)
     );
   };
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  addMistake(_mistake: Mistake): void {}
 
   considerBox = (box: Box): void => {
     this.boxesToInstancesMap[box.qualifiedName] = MIN_SEGMENT_LENGTHS.map(minSegmentLength => ({

--- a/src/imap/promisified.ts
+++ b/src/imap/promisified.ts
@@ -77,11 +77,11 @@ export default class Promisified {
   }; // fetch(source: any /* MessageSource */, options: FetchOptions): ImapFetch
 
   private setBoxListener = (listener: BoxListener): void => {
-    this.imap.on('close', listener.onClose);
-    this.imap.on('end', listener.onEnd);
-    this.imap.on('expunge', listener.onExpunge);
-    this.imap.on('mail', listener.onMail);
-    this.imap.on('uidvalidity', listener.onUidValidity);
+    this.imap.on('close', listener.onClose.bind(listener));
+    this.imap.on('end', listener.onEnd.bind(listener));
+    this.imap.on('expunge', listener.onExpunge.bind(listener));
+    this.imap.on('mail', listener.onMail.bind(listener));
+    this.imap.on('uidvalidity', listener.onUidValidity.bind(listener));
     ['alert', 'update'].forEach(event => {
       this.imap.on(event, (...args: any[]) => {
         logger.error({

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,6 @@ function handleError(reason: Error): void {
   }, 10);
 }
 
-export async function startServer(): Promise<object>;
 export async function startServer() {
   process.on('uncaughtException', (reason: Error) => {
     handleError(reason);

--- a/src/types/mistake.ts
+++ b/src/types/mistake.ts
@@ -1,0 +1,19 @@
+import {Record, Static, String} from 'runtypes';
+
+import Move, {MoveRecord} from './move';
+
+export const MistakeRecord = Record({
+  correctDestination: String,
+  errantMove: MoveRecord
+});
+
+type Mistake = Static<typeof MistakeRecord>;
+
+export default Mistake;
+
+export function createMistake(correctDestination: string, move: Move): Mistake {
+  return {
+    correctDestination,
+    errantMove: move
+  };
+}

--- a/test/api/mailMovement.ts
+++ b/test/api/mailMovement.ts
@@ -4,11 +4,12 @@ import * as _ from 'lodash';
 import * as mockery from 'mockery';
 import * as sinon from 'sinon';
 
-import mockImap, {MockResult as ImapMock} from './mocks/imap';
+import mockImap from './mocks/imap';
+import ImapMock from './mocks/imap/mockResult';
 import boxes from './tools/fixture/standard/boxes';
 import bunyan, {MockResult as BunyanMock} from './mocks/bunyan';
 import {useFixture} from './tools/fixture/standard/useFixture';
-import {EventHandlers, startServerInHealthyState} from './tools/server';
+import {startServerInHealthyState} from './tools/server';
 import {fromBoxes} from './mocks/imap/serverState';
 import {mockStorageAndSetEnvironment} from './mocks/mailFamiliarStorage';
 import {until} from './tools/wait';
@@ -18,7 +19,6 @@ let clock: sinon.SinonFakeTimers;
 let imapMock: ImapMock;
 
 describe('mail movement', () => {
-  let eventHandlers: EventHandlers;
   let server: any;
 
   beforeEach(async () => {
@@ -64,7 +64,7 @@ describe('mail movement', () => {
 
     mockery.registerMock('imap', imapMock.class);
 
-    ({eventHandlers, server} = await startServerInHealthyState(imapMock));
+    server = await startServerInHealthyState();
     await until(() => bunyanMock.logger.info.calledWith(`shallow sync complete`));
   });
 
@@ -89,7 +89,7 @@ describe('mail movement', () => {
     beforeEach(async () => {
       imapMock.object.openBox.reset();
       bunyanMock.logger.info.reset();
-      await eventHandlers.on.expunge(40465);
+      await imapMock.eventHandlers.on.expunge(40465);
       await until(() => bunyanMock.logger.info.calledWith(`shallow sync complete`));
     });
 

--- a/test/api/mocks/imap/fakeBox.ts
+++ b/test/api/mocks/imap/fakeBox.ts
@@ -1,7 +1,7 @@
 import * as crypto from 'crypto';
 
 import FolderState from './folderState';
-import {MockMessage} from '.';
+import MockMessage from './mockMessage';
 
 const WEEK_MS = 1000 * 60 * 60 * 24 * 7;
 

--- a/test/api/mocks/imap/mockResult.ts
+++ b/test/api/mocks/imap/mockResult.ts
@@ -1,6 +1,14 @@
 import MockMessage from './mockMessage';
 import ServerState from './serverState';
-import {EventHandlers} from '../../tools/server';
+
+export interface EventHandlers {
+  on: {
+    [key: string]: any;
+  };
+  once: {
+    [key: string]: any;
+  };
+}
 
 export interface Simulate {
   event: {
@@ -9,11 +17,12 @@ export interface Simulate {
     mail: (count: number) => void;
     uidValidity: (validity: number) => void;
   };
-  mailReceived: (mails: MockMessage[], handlers: EventHandlers) => Promise<void>;
+  mailReceived: (mails: MockMessage[]) => Promise<void>;
 }
 
 export default interface MockResult {
   class: any;
+  eventHandlers: EventHandlers;
   fetchReturnsWith: (mails: MockMessage[]) => void;
   object: any;
   setServerState: (state: ServerState) => void;

--- a/test/api/periodicRefresh.ts
+++ b/test/api/periodicRefresh.ts
@@ -5,7 +5,8 @@ import * as mockery from 'mockery';
 import * as sinon from 'sinon';
 
 import bunyan, {MockResult as BunyanMock} from './mocks/bunyan';
-import mockImap, {MockResult as ImapMock} from './mocks/imap';
+import mockImap from './mocks/imap';
+import ImapMock from './mocks/imap/mockResult';
 import boxes from './tools/fixture/standard/boxes';
 import {useFixture} from './tools/fixture/standard/useFixture';
 import {startServerInHealthyState} from './tools/server';
@@ -43,7 +44,7 @@ describe('periodic refresh', () => {
       now: 1547375767863,
       shouldAdvanceTime: true
     });
-    ({server} = await startServerInHealthyState(imapMock));
+    server = await startServerInHealthyState();
   });
 
   afterEach(async () => {

--- a/test/api/startup.ts
+++ b/test/api/startup.ts
@@ -7,7 +7,8 @@ import * as path from 'path';
 import {stub, SinonStub} from 'sinon';
 
 import bunyan, {MockResult as BunyanMock} from './mocks/bunyan';
-import mockImap, {MockResult as ImapMock} from './mocks/imap';
+import mockImap from './mocks/imap';
+import ImapMock from './mocks/imap/mockResult';
 import {mockStorageAndSetEnvironment, MockResult as StorageMock} from './mocks/mailFamiliarStorage';
 import {until, waitATick} from './tools/wait';
 
@@ -93,6 +94,12 @@ describe('startup', () => {
           }
         }
       });
+    });
+
+    afterEach(async () => {
+      server = await serverPromise;
+
+      server.stop();
     });
 
     it('registers an error handler', () => {

--- a/test/api/tools/server.ts
+++ b/test/api/tools/server.ts
@@ -1,68 +1,12 @@
-import {expect} from '@hapi/code';
 import * as _ from 'lodash';
 import * as path from 'path';
-// tslint:disable-next-line: no-var-requires
-const promiseRetry = require('promise-retry');
-
-import {MockResult} from '../mocks/imap';
 
 const ROOT = process.cwd();
 const SERVER = path.join(ROOT, 'src', 'index');
 
-export interface EventHandlers {
-  on: {
-    [key: string]: any;
-  };
-  once: {
-    [key: string]: any;
-  };
-}
-
-export interface StartServerResult {
-  eventHandlers: EventHandlers;
-  server: any;
-}
-
-export async function startServerInHealthyState(imapMock: MockResult): Promise<StartServerResult> {
+export async function startServerInHealthyState(): Promise<any> {
   const {startServer} = require(SERVER);
+  const server = await startServer();
 
-  const eventHandlers: EventHandlers = {
-    on: {},
-    once: {}
-  };
-  const serverPromise: Promise<any> = startServer();
-
-  await promiseRetry((retry: (error: any) => never, attempt: number) => {
-    return new Promise((resolve, reject) => {
-      setTimeout(() => {
-        imapMock.object.once.args.forEach((args: Array<any>) => {
-          expect(args.length).to.equal(2);
-          eventHandlers.once[args[0]] = args[1];
-        });
-        imapMock.object.on.args.forEach((args: Array<any>) => {
-          expect(args.length).to.equal(2);
-          eventHandlers.on[args[0]] = args[1];
-        });
-        if (eventHandlers.once.ready) {
-          resolve();
-        } else {
-          reject(new Error('eventHandlers.once.ready not set'));
-        }
-      }, 10);
-    }).catch(error => {
-      if (attempt < 4) {
-        retry(error);
-      }
-
-      throw error;
-    });
-  });
-
-  eventHandlers.once.ready();
-  const server = await serverPromise;
-
-  return {
-    eventHandlers,
-    server
-  };
+  return server;
 }

--- a/test/unit/engine/mistakeTracker.ts
+++ b/test/unit/engine/mistakeTracker.ts
@@ -1,0 +1,94 @@
+import _ = require('lodash');
+import Sinon = require('sinon');
+
+import {expect} from '@hapi/code';
+const {beforeEach, describe, it} = (exports.lab = require('@hapi/lab').script());
+
+import Box from '../../../src/engine/box';
+import MistakeTracker from '../../../src/engine/mistakeTracker';
+import Move, {createMove} from '../../../src/types/move';
+import Mistake from 'types/mistake';
+
+describe('MistakeTracker', () => {
+  const headers: ReadonlyArray<string> = ['abc', 'def', 'ghi', 'jkl'];
+  const INBOX: string = 'INBOX';
+  const IMPORTANT: string = 'IMPORTANT';
+  const SPAM: string = 'SPAM';
+  const date: Date = new Date();
+
+  let boxen: Box[];
+  let moves: Move[];
+  let mistakeTracker: MistakeTracker;
+  let observer: Sinon.SinonStub;
+
+  beforeEach(() => {
+    boxen = [
+      new Box({
+        messages: [{date, headers: 'abc', seq: 1, uid: 2}],
+        name: INBOX,
+        qualifiedName: INBOX,
+        syncedTo: Date.now()
+      })
+    ];
+    moves = _.map(
+      _.zip([IMPORTANT, IMPORTANT, SPAM, SPAM], headers),
+      ([destination, headersString]) =>
+        createMove(
+          destination as string,
+          {date, headers: headersString as string, seq: 1, uid: 2},
+          date
+        )
+    );
+    observer = Sinon.stub();
+
+    mistakeTracker = new MistakeTracker(moves, boxen, (mistake: Mistake): void => {
+      observer(mistake);
+    });
+  });
+
+  it('provides an empty set of mistakes for unknown destinations', () => {
+    expect([mistakeTracker.mistakesFor('not there')]).to.equal([{}]);
+  });
+
+  it('lists mistakes for known destinations', () => {
+    expect([mistakeTracker.mistakesFor(IMPORTANT)]).to.equal([
+      {
+        abc: {
+          correctDestination: INBOX,
+          errantMove: createMove(IMPORTANT, {date, headers: 'abc', seq: 1, uid: 2}, date)
+        }
+      }
+    ]);
+    expect(observer.called).to.be.true();
+  });
+
+  it('discovers mistakes as new move results come in', () => {
+    expect([mistakeTracker.mistakesFor(SPAM)]).to.equal([{}]);
+    const message1 = {date, headers: 'ghi', seq: 1, uid: 2};
+    mistakeTracker.inspectMessage(INBOX, message1);
+    expect([mistakeTracker.mistakesFor(SPAM)]).to.equal([
+      {
+        ghi: {
+          correctDestination: INBOX,
+          errantMove: createMove(SPAM, message1, date)
+        }
+      }
+    ]);
+    expect(observer.called).to.be.true();
+    const message2 = {date, headers: 'mno', seq: 1, uid: 2};
+    mistakeTracker.addMove(createMove(SPAM, message2, date));
+    mistakeTracker.inspectMessage(IMPORTANT, message2);
+    expect([mistakeTracker.mistakesFor(SPAM)]).to.equal([
+      {
+        ghi: {
+          correctDestination: INBOX,
+          errantMove: createMove(SPAM, message1, date)
+        },
+        mno: {
+          correctDestination: IMPORTANT,
+          errantMove: createMove(SPAM, message2, date)
+        }
+      }
+    ]);
+  });
+});

--- a/test/unit/engine/userConnection.ts
+++ b/test/unit/engine/userConnection.ts
@@ -101,6 +101,7 @@ describe('userConnection', () => {
 
     predictor = {
       addHeaders: sinon.stub(),
+      addMistake: sinon.stub(),
       considerBox: sinon.stub(),
       folderScore: sinon.stub(),
       name: sinon.stub().returns('name'),


### PR DESCRIPTION
This has been a significant flaw in the prior approach. There was no way for predictors to learn from their mistakes.

A mistake is defined as a message that was moved by `mailFamiliar` to folder A, which is later discovered in folder B. Since we have a record of moves, it's possible to derive historical mistakes and take them into account too.