### PR TITLE
Handle box deletion

### DIFF
--- a/src/engine/exceptions.ts
+++ b/src/engine/exceptions.ts
@@ -1,5 +1,27 @@
+import Box from './box';
+
 export class BadStateException extends Error {
   constructor(message: string) {
     super(message);
+  }
+}
+
+export class BoxDeletedException extends Error {
+  public readonly deleted: Box;
+
+  constructor(deleted: Box) {
+    super('Box was deleted');
+    this.deleted = deleted;
+  }
+
+  public static checkAndThrow(box: Box, e: Error): never {
+    if (
+      e.name === 'Error' &&
+      e.message &&
+      e.message.toString().startsWith("Mailbox doesn't exist: ")
+    ) {
+      throw new BoxDeletedException(box);
+    }
+    throw e;
   }
 }

--- a/test/api/folderChanges.ts
+++ b/test/api/folderChanges.ts
@@ -1,0 +1,120 @@
+import {expect} from '@hapi/code';
+const {afterEach, beforeEach, describe, it} = (exports.lab = require('@hapi/lab').script());
+import * as mockery from 'mockery';
+import * as sinon from 'sinon';
+
+import {Box} from 'imap';
+
+import mockImap from './mocks/imap';
+import ImapMock from './mocks/imap/mockResult';
+import ServerState, {fromBoxes} from './mocks/imap/serverState';
+import boxes from './tools/fixture/standard/boxes';
+import bunyan, {MockResult as BunyanMock} from './mocks/bunyan';
+import {useFixture} from './tools/fixture/standard/useFixture';
+import {startServerInHealthyState} from './tools/server';
+import {mockStorageAndSetEnvironment} from './mocks/mailFamiliarStorage';
+import {until} from './tools/wait';
+
+let bunyanMock: BunyanMock;
+let clock: sinon.SinonFakeTimers;
+let imapMock: ImapMock;
+
+const INBOX = 'INBOX';
+const INTERESTING_SPAM = 'Interesting spam';
+
+describe('folder', () => {
+  const inbox = [
+    {
+      attributes: {
+        date: new Date('2018-12-25T12:21:37.000Z'),
+        flags: [],
+        size: 1234,
+        uid: 41,
+      },
+      body: Buffer.from('whut up?'),
+      seqno: 41,
+      synced: true,
+    },
+  ];
+  const interestingSpam = [
+    {
+      attributes: {
+        date: new Date('2018-12-26T01:09:55.000Z'),
+        flags: [],
+        size: 15711,
+        uid: 68,
+      },
+      body: Buffer.from('interesting spam like this'),
+      seqno: 68,
+      synced: true,
+    },
+  ];
+
+  let server: any;
+  let serverState: ServerState;
+
+  beforeEach(async () => {
+    mockery.enable({
+      useCleanCache: true,
+      warnOnReplace: false,
+      warnOnUnregistered: false,
+    });
+
+    clock = sinon.useFakeTimers({
+      now: new Date('2019-01-01T00:00:00.000Z'),
+      shouldAdvanceTime: true,
+    });
+
+    bunyanMock = bunyan();
+
+    mockery.registerMock('bunyan', bunyanMock.object);
+
+    await useFixture();
+
+    mockStorageAndSetEnvironment();
+
+    imapMock = mockImap();
+    serverState = fromBoxes(boxes);
+    const inboxState = serverState.folders.INBOX;
+    inboxState.messages = inbox;
+    inboxState.messageState.total = inbox.length;
+    const interestingSpamState = serverState.folders[INTERESTING_SPAM];
+    interestingSpamState.messages = interestingSpam;
+    interestingSpamState.messageState.total = interestingSpam.length;
+
+    imapMock.setServerState(serverState);
+
+    mockery.registerMock('imap', imapMock.class);
+
+    server = await startServerInHealthyState();
+    await until(() => bunyanMock.logger.info.calledWith(`shallow sync complete`));
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await server.stop();
+      server = null;
+    }
+
+    clock.restore();
+    mockery.disable();
+  });
+
+  describe('deletion', () => {
+    beforeEach(async () => {
+      const newBoxes: Box[] = [];
+      boxes.filter((box) => box.name !== INTERESTING_SPAM).forEach((box) => newBoxes.push(box));
+      const newState = fromBoxes(newBoxes);
+      newState.currentlyOpenBox = INBOX;
+      imapMock.setServerState(newState);
+      imapMock.object.getBoxes.reset();
+      bunyanMock.logger.info.reset();
+      clock.tick('01:00:00');
+      await until(() => bunyanMock.logger.info.calledWith('shallow sync complete'));
+    });
+
+    it('discovers the folders again', () => {
+      expect(imapMock.object.getBoxes.called).to.be.true();
+    });
+  });
+});

--- a/test/api/mocks/imap/index.ts
+++ b/test/api/mocks/imap/index.ts
@@ -249,7 +249,7 @@ export default function imap(): MockResult {
   replaceReset(object.openBox, () => {
     object.openBox.callsFake((boxName: string, callback: (result: Error | null) => void) => {
       if (Object.keys(object._state.folders).indexOf(boxName) === -1) {
-        return callback(new Error(`Folder ${boxName} isn't present.`));
+        return callback(new Error(`Mailbox doesn't exist: ${boxName}`));
       }
 
       object._currentlyOpened = boxName;


### PR DESCRIPTION
There's a crash when mailboxes are deleted that looks like this:

```
Error: Mailbox doesn't exist: Junk
    at Connection._resTagged (/usr/local/bin/mailFamiliar/node_modules/imap/lib/Connection.js:1502:11)
    at Parser.<anonymous> (/usr/local/bin/mailFamiliar/node_modules/imap/lib/Connection.js:194:10)
    at Parser.emit (events.js:310:20)
    at Parser._resTagged (/usr/local/bin/mailFamiliar/node_modules/imap/lib/Parser.js:175:10)
    at Parser._parse (/usr/local/bin/mailFamiliar/node_modules/imap/lib/Parser.js:139:16)
    at Parser._tryread (/usr/local/bin/mailFamiliar/node_modules/imap/lib/Parser.js:82:15)
    at TLSSocket.Parser._cbReadable (/usr/local/bin/mailFamiliar/node_modules/imap/lib/Parser.js:53:12)
    at TLSSocket.emit (events.js:310:20)\n    at emitReadable_ (_stream_readable.js:543:12)
    at processTicksAndRejections (internal/process/task_queues.js:83:21)
```